### PR TITLE
chore: update legal entity name to iGrant Technologies AB

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2021-2025] [LCubed AB, Sweden (iGrant.io)]
+   Copyright [2021-2025] [iGrant Technologies AB, Sweden (iGrant.io)]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2021-2025] [iGrant Technologies AB, Sweden (iGrant.io)]
+   Copyright [2026] [iGrant Technologies AB, Sweden (iGrant.io)]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Feel free to improve the plugin and send us a pull request. If you find any prob
 
 ## Licensing
 
-Copyright (c) 2023-25 iGrant Technologies AB (iGrant.io), Sweden
+Copyright (c) 2026 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache 2.0 License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Feel free to improve the plugin and send us a pull request. If you find any prob
 
 ## Licensing
 
-Copyright (c) 2023-25 LCubed AB (iGrant.io), Sweden
+Copyright (c) 2023-25 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache 2.0 License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -33,7 +33,7 @@ Feel free to improve the plugin and send us a pull request. If you find any prob
 
 ## Licensing
 
-Copyright (c) 2023-25 iGrant Technologies AB (iGrant.io), Sweden
+Copyright (c) 2026 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache 2.0 License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -33,7 +33,7 @@ Feel free to improve the plugin and send us a pull request. If you find any prob
 
 ## Licensing
 
-Copyright (c) 2023-25 LCubed AB (iGrant.io), Sweden
+Copyright (c) 2023-25 iGrant Technologies AB (iGrant.io), Sweden
 
 Licensed under the Apache 2.0 License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 


### PR DESCRIPTION
Our legal entity name is now **iGrant Technologies AB**, formerly **LCubed AB**.

This PR replaces references to the old legal entity name **LCubed AB** with the new name **iGrant Technologies AB** in licensing/copyright, legal, and current branding text.

Left unchanged: technical identifiers, i18n keys, file names/URLs, and historical records.